### PR TITLE
GitHub Action to Deploy to Staging

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,5 +35,6 @@ jobs:
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
           deploy_alias: ${{ env.BRANCH_NAME }}
           build_directory: "./dist"
+          debug: ${{env.DEBUG_BUILD}}
       
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,9 +19,6 @@ jobs:
     name: 'Build and Deploy'
     runs-on: ubuntu-latest
     environment: netlify-wills-org
-    env: 
-      NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
-      debug: ${{ env.DEBUG_BUILD }}
     steps:
       - name: Install Netlify 
         run: npm install -g netlify-cli
@@ -33,7 +30,7 @@ jobs:
       - uses: jsmrcaga/action-netlify-deploy@v2.4.0
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
           deploy_alias: ${{ BRANCH_NAME }}
           build_directory: "./dist"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,7 @@ jobs:
   deploy:
     name: 'Deploy'
     runs-on: ubuntu-latest
+    environment: netlify-wills-org
 
     steps:
       - name: Install Netlify 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   deploy:
-    name: 'Deploy'
+    name: 'Build and Deploy'
     runs-on: ubuntu-latest
     environment: netlify-wills-org
 
@@ -25,10 +25,10 @@ jobs:
       - name: Install Netlify 
         run: npm install -g netlify-cli
 
+      # Used to checkout the current branch at HEAD from this repo
       - uses: actions/checkout@v3
 
-      # Sets the branch name as environment variable
-      - uses: nelonoel/branch-name@v1.0.1
+      # Runs the netlify deploy commands
       - uses: jsmrcaga/action-netlify-deploy@v2.0.0
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   deploy:
-    name: 'Build and Deploy'
+    name: 'Build and Deploy to Staging'
     runs-on: ubuntu-latest
-    environment: netlify-wills-org
+    environment: staging
     steps:
       - name: Install Netlify 
         run: npm install -g netlify-cli
@@ -30,11 +30,11 @@ jobs:
       - uses: jsmrcaga/action-netlify-deploy@v2.4.0
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
-          deploy_alias: "staging-build"
+          deploy_alias: ${{ vars.DEPLOY_ALIAS }}
           build_directory: "./dist"
-          debug: ${{ env.DEBUG_BUILD }}
+          debug: ${{ vars.DEBUG_BUILD }}
           build_command: netlify build
           install_command: npm install
       

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,8 @@ jobs:
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
           deploy_alias: ${{ env.BRANCH_NAME }}
           build_directory: "./dist"
-          build_commpand: netlify build
+          debug: ${{ env.DEBUG_BUILD }}
+          build_command: netlify build
           install_command: npm install
       
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,7 +12,6 @@ on:
 # Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 jobs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,13 +28,14 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs the netlify deploy commands
-      - uses: jsmrcaga/action-netlify-deploy@v2.0.0
+      - uses: jsmrcaga/action-netlify-deploy@v2.4.0
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
           deploy_alias: ${{ env.BRANCH_NAME }}
           build_directory: "./dist"
-          debug: ${{env.DEBUG_BUILD}}
+          build_commpand: netlify build
+          install_command: npm install
       
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
-          deploy_alias: ${{ env.BRANCH_NAME }}
+          deploy_alias: "staging-build"
           build_directory: "./dist"
           debug: ${{ env.DEBUG_BUILD }}
           build_command: netlify build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
-          deploy_alias: ${{ BRANCH_NAME }}
+          deploy_alias: ${{ env.BRANCH_NAME }}
           build_directory: "./dist"
           debug: ${{ env.DEBUG_BUILD }}
           build_command: netlify build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,9 @@ jobs:
     name: 'Build and Deploy'
     runs-on: ubuntu-latest
     environment: netlify-wills-org
-
+    env: 
+      NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
+      debug: ${{ env.DEBUG_BUILD }}
     steps:
       - name: Install Netlify 
         run: npm install -g netlify-cli
@@ -33,7 +35,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
           NETLIFY_DEPLOY_MESSAGE: "Test deploy v${{ github.ref }}"
-          deploy_alias: ${{ env.BRANCH_NAME }}
+          deploy_alias: ${{ BRANCH_NAME }}
           build_directory: "./dist"
           debug: ${{ env.DEBUG_BUILD }}
           build_command: netlify build

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pnpm-debug.log*
 .env
 .env.production
 .secrets
+.vars
 
 # macOS-specific files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Thank you for your interest in improving the Orlando Devs website! This is an op
 If you are a group admin and want to make an update to your group's profile, clone the repo and edit your group file under `website/src/content/groups/your-group.md`. Include or omit as much as you feel necessary.
 
 ## Going Further
-If you have your own Netlify account and want to test the GitHub actions ahead of time, install [Act](https://github.com/nektos/act). Create a `.env` file with `NETLIFY_SITE_ID` and `BRANCH_NAME` set. Create a `.secrets` file and set `NETLIFY_AUTH_TOKEN`. The format for both files is `BRANCH_NAME="my-cool-branch"` in pairs. Once your files are in place, run  `act -s --secret-file .secrets`. Assuming all of your code compiles, the runner should complete and you should have a staging version of the site deployed at the preview URL provided. Example output of a successful job:
+If you have your own Netlify account and want to test the GitHub actions ahead of time, install [Act](https://github.com/nektos/act). Create a `.vars` file with `NETLIFY_SITE_ID` and `BRANCH_NAME` set. Create a `.secrets` file and set `NETLIFY_AUTH_TOKEN`. The format for both files is `BRANCH_NAME="my-cool-branch"` in pairs. Once your files are in place, run  `act -s --secret-file .secrets`. Assuming all of your code compiles, the runner should complete and you should have a staging version of the site deployed at the preview URL provided. Example output of a successful job:
 
 ```
 Build logs:         https://app.netlify.com/sites/odevs-pipeline-testing/deploys/678d0d409e40cd228387f837


### PR DESCRIPTION
"Staging" right now defined as a Netlify org I stood up and have sole access to. It would be much preferable to create a deploy in the ODevs Netlify org we can stage to. 

However, you can see the prior actions to see this is successful. All builds will publish to `https://staging-build--odevs-pipeline-testing.netlify.app/` as that is what the `vars.DEPLOY_ALIAS` is configured for. 